### PR TITLE
Fetch citations via r.jina.ai proxy

### DIFF
--- a/assets/js/scholar.js
+++ b/assets/js/scholar.js
@@ -1,8 +1,8 @@
 // Fetch Google Scholar profile and display publication data in real-time
-// Uses a public CORS proxy to access the Google Scholar profile page
+// Uses the r.jina.ai proxy to bypass CORS on Google Scholar
 async function loadScholar() {
   const profileUrl =
-    'https://cors.isomorphic-git.org/https://scholar.google.com/citations?user=KUDBcugAAAAJ&hl=en&cstart=0&pagesize=100';
+    'https://r.jina.ai/https://scholar.google.com/citations?user=KUDBcugAAAAJ&hl=en&cstart=0&pagesize=100';
   try {
     const resp = await fetch(profileUrl);
     if (!resp.ok) throw new Error('Network response was not ok');


### PR DESCRIPTION
## Summary
- fetch Google Scholar HTML via `r.jina.ai` proxy again
- parse citations on page load
- drop unused manual update script and JSON cache
- remove `scholarly` from requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848e0ea82b08323ba69865a5038c705